### PR TITLE
Map refactor

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -34,16 +34,12 @@ function App() {
   let index = []
   
   Object.keys(citiesIndex).forEach(item => {
-    if(citiesIndex[item].population > 500000){
       // console.log(citiesIndex[item])
       let city = citiesIndex[item]
       city.name = item
       index.push(city)
-
-    }
-
   })
-  // console.log(index, "INDEX")
+
 
   const [user, setUser] = useState({});
   const [cityMarkers, setCityMarkers] = useState(index);
@@ -61,10 +57,24 @@ function App() {
   });
 
   useEffect( _ => {
+    console.log(viewport.zoom)
+    if (viewport.zoom < 4) {
+      setCityMarkers(index.filter(city => city.population > 500000))
+    }
+    if (viewport.zoom >= 4 && viewport.zoom < 5) {
+      setCityMarkers(index.filter(city => city.population > 300000))
+    }
+    if (viewport.zoom >= 5 && viewport.zoom < 6) {
+      setCityMarkers(index.filter(city => city.population > 100000))
+    }
+  },[viewport.zoom])
+
+
+  //Analytics Events
+  useEffect( _ => {
     ReactGA.event({ category: 'Map', 
     action: 'Changed map location' });
   }, [viewport.latitude])
-
   useEffect( _ => {
     ReactGA.event({ category: 'Map', 
     action: 'Changed map zoom' });

--- a/src/App.js
+++ b/src/App.js
@@ -55,7 +55,7 @@ function App() {
 
 
   });
-
+// this filters the map markers based on zoom - Closer zoom, lesser population cap
   useEffect( _ => {
     console.log(viewport.zoom)
     if (viewport.zoom < 4) {

--- a/src/App.js
+++ b/src/App.js
@@ -57,7 +57,6 @@ function App() {
   });
 // this filters the map markers based on zoom - Closer zoom, lesser population cap
   useEffect( _ => {
-    console.log(viewport.zoom)
     if (viewport.zoom < 4) {
       setCityMarkers(index.filter(city => city.population > 500000))
     }

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -92,6 +92,8 @@ const selectSearch = cityMarker =>  {
           latitude: found.lat
       })
       } else {
+        ReactGA.event({ category: 'Data', 
+        action: `used suggestion endpoint: ${search}` });
         getBestSuggestion(search);
       }   
     }

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -37,6 +37,7 @@ export default function Map() {
     .then(res => {
       // if there's a suggestion
       if (res.data) {
+        // get the best (first) suggestion and add it to state
         let suggestionKey = Object.keys(res.data)[0]
         getCity(res.data[suggestionKey])  
       }

--- a/src/components/map-components/DataDisplay.js
+++ b/src/components/map-components/DataDisplay.js
@@ -1,5 +1,6 @@
 import  React, {useState, useEffect} from "react";
 import { Link, Element, Events, animateScroll as scroll, scrollSpy, scroller } from 'react-scroll'
+import ReactGA from "react-ga";
 
 import MapSearch from "./MapSearch";
 import LineGraph from "../graphs/housing/House_price";
@@ -17,7 +18,6 @@ import deleteIcon from "./icons/close_red.png";
 const DataDisplay = ({search, selected, toggleSelected, onSearch, setSearch, cityMarkers, viewport, setViewport, selectSearch}) => {
 
     const [menu, setMenu] = useState({status: 'closed'})
-    const [offset, setOffset] = useState(0);
 
     const dataNavClicked = link => {
         ReactGA.event({ category: 'Data', 
@@ -26,7 +26,6 @@ const DataDisplay = ({search, selected, toggleSelected, onSearch, setSearch, cit
 
     // fixed sidebar handling
     window.onscroll = _ => scrollAnchor();
-
     var stickynav = document.getElementById("stickynav");
     if (stickynav) {
         // This line handles the offset from the main nav bar - If we unfix the main nav bar
@@ -34,19 +33,13 @@ const DataDisplay = ({search, selected, toggleSelected, onSearch, setSearch, cit
         var sticky = stickynav.offsetTop - 83;
     }
 
-const scrollAnchor = _ => {
-    if (window.pageYOffset > sticky) {
-        stickynav.classList.add("sticky");
-    } else {
-        stickynav.classList.remove("sticky");
+    const scrollAnchor = _ => {
+        if (window.pageYOffset > sticky) {
+            stickynav.classList.add("sticky");
+        } else {
+            stickynav.classList.remove("sticky");
+        }
     }
-}
-    
-
-
-
-
-    // console.log(selected)
 
     const toggleMenu = () => {
         if (menu.status === 'closed') {
@@ -54,10 +47,6 @@ const scrollAnchor = _ => {
         } else if (menu.status === 'open') {
             setMenu({...menu, status:'closed'})
         }
-    }
-
-    const toggleVisibility = city => {
-        console.log("toggling visibility of ", city.city)
     }
      
     return (
@@ -109,7 +98,7 @@ const scrollAnchor = _ => {
                         </div>
                     </div>
                     <ul>
-                        {selected.map(item => <div key={item._id} className={`menu-items ${menu.status}`}><li  key={item._id} onClick={ _ => toggleVisibility(item)}>{item.name_with_com} 
+                        {selected.map(item => <div key={item._id} className={`menu-items ${menu.status}`}><li  key={item._id}>{item.name_with_com} 
                             <span onClick={ _ => toggleSelected(item)}>
                                 <img className="delete-icon" src={deleteIcon} alt="delete icon" />
                             </span>

--- a/src/components/map-components/DataDisplay.js
+++ b/src/components/map-components/DataDisplay.js
@@ -27,19 +27,36 @@ const DataDisplay = ({search, selected, toggleSelected, onSearch, setSearch, cit
     // fixed sidebar handling
     window.onscroll = _ => scrollAnchor();
     var stickynav = document.getElementById("stickynav");
+    var height = document.body.scrollHeight;
     if (stickynav) {
         // This line handles the offset from the main nav bar - If we unfix the main nav bar
         // (i believe we will) - the subtraction will be unnecessary.
         var sticky = stickynav.offsetTop - 83;
     }
 
+    var isScrolledToFooter = _ => 
+        window.pageYOffset > document.body.scrollHeight - window.innerHeight - 300;
+
+    
+
+    
+
+
     const scrollAnchor = _ => {
-        if (window.pageYOffset > sticky) {
+        if (window.pageYOffset > sticky && !isScrolledToFooter()) {
             stickynav.classList.add("sticky");
         } else {
             stickynav.classList.remove("sticky");
         }
+        if (isScrolledToFooter() && selected.length > 0) {
+            stickynav.classList.add("nav-bottom-anchor")
+        } 
+        else {
+            stickynav.classList.remove("nav-bottom-anchor")
+        }
     }
+
+    
 
     const toggleMenu = () => {
         if (menu.status === 'closed') {

--- a/src/components/map-components/DataDisplay.js
+++ b/src/components/map-components/DataDisplay.js
@@ -37,7 +37,16 @@ const DataDisplay = ({search, selected, toggleSelected, onSearch, setSearch, cit
     var isScrolledToFooter = _ => 
         window.pageYOffset > document.body.scrollHeight - window.innerHeight - 300;
 
+    const colorifier = lat => {
+
+        let arr = String(lat).replace(".","").split("");
     
+        let num1 = arr.pop();
+        let num2 = arr.pop();
+        let num3 = arr.pop();
+    
+        return `rgb(${num1 * 28}, ${num2 * 28}, ${num3 * 28})`
+        }
 
     
 
@@ -115,11 +124,14 @@ const DataDisplay = ({search, selected, toggleSelected, onSearch, setSearch, cit
                         </div>
                     </div>
                     <ul>
-                        {selected.map(item => <div key={item._id} className={`menu-items ${menu.status}`}><li  key={item._id}>{item.name_with_com} 
-                            <span onClick={ _ => toggleSelected(item)}>
-                                <img className="delete-icon" src={deleteIcon} alt="delete icon" />
-                            </span>
-                        </li></div>)}
+                        {selected.map(item => 
+                        <div key={item._id} className={`menu-items ${menu.status}`}>
+                            <li key={item._id}><span className="color-legend-text"><div className="color-legend" style={{display: "inline-block", background: colorifier(item.Longitude), height: "1rem", width: "1rem", marginRight: ".5rem"}}></div>{item.name_with_com}</span> 
+                                <span onClick={ _ => toggleSelected(item)}>
+                                    <img className="delete-icon" src={deleteIcon} alt="delete icon" />
+                                </span>
+                            </li>
+                        </div>)}
                     </ul>
                 </div>    
             </nav>

--- a/src/components/map-components/DataDisplay.js
+++ b/src/components/map-components/DataDisplay.js
@@ -19,6 +19,11 @@ const DataDisplay = ({search, selected, toggleSelected, onSearch, setSearch, cit
     const [menu, setMenu] = useState({status: 'closed'})
     const [offset, setOffset] = useState(0);
 
+    const dataNavClicked = link => {
+        ReactGA.event({ category: 'Data', 
+        action: `clicked ${link} link` });
+    }
+
     // fixed sidebar handling
     window.onscroll = _ => scrollAnchor();
 
@@ -88,17 +93,17 @@ const scrollAnchor = _ => {
                             {selected.length > 0 
                             ? <div className="anchor-nav">
                                 <h4 className="anchor-header">Housing</h4>
-                                <Link activeClass="active" className="anchor-link" to="homeprice" spy={true} smooth={true} duration={500} >Housing Costs</Link>
-                                <Link activeClass="active" className="anchor-link" to="rent" spy={true} smooth={true} duration={500} >Rent</Link>
-                                <Link activeClass="active" className="anchor-link" to="rooms" spy={true} smooth={true} duration={500} >Rooms</Link>
+                                <Link onClick={() => dataNavClicked("housing costs")} activeClass="active" className="anchor-link" to="homeprice" spy={true} smooth={true} duration={500} >Housing Costs</Link>
+                                <Link onClick={() => dataNavClicked("rent")} activeClass="active" className="anchor-link" to="rent" spy={true} smooth={true} duration={500} >Rent</Link>
+                                <Link onClick={() => dataNavClicked("rooms")} activeClass="active" className="anchor-link" to="rooms" spy={true} smooth={true} duration={500} >Rooms</Link>
                                 <h4 className="anchor-header">Jobs</h4>
-                                <Link activeClass="active" className="anchor-link" to="industries" spy={true} smooth={true} duration={500} >Industries</Link>
-                                <Link activeClass="active" className="anchor-link" to="salary" spy={true} smooth={true} duration={500} >Salary</Link>
-                                <Link activeClass="active" className="anchor-link" to="commute" spy={true} smooth={true} duration={500} >Commute</Link>
+                                <Link onClick={() => dataNavClicked("industries")} activeClass="active" className="anchor-link" to="industries" spy={true} smooth={true} duration={500} >Industries</Link>
+                                <Link onClick={() => dataNavClicked("salary")} activeClass="active" className="anchor-link" to="salary" spy={true} smooth={true} duration={500} >Salary</Link>
+                                <Link onClick={() => dataNavClicked("commute")} activeClass="active" className="anchor-link" to="commute" spy={true} smooth={true} duration={500} >Commute</Link>
                                 <h4 className="anchor-header">Culture</h4>
-                                <Link activeClass="active" className="anchor-link" to="education" spy={true} smooth={true} duration={500} >Education</Link>
-                                <Link activeClass="active" className="anchor-link" to="ethnicity" spy={true} smooth={true} duration={500} >Ethnicity</Link>
-                                <Link activeClass="active" className="anchor-link" to="population" spy={true} smooth={true} duration={500} >Population</Link>
+                                <Link onClick={() => dataNavClicked("education")} activeClass="active" className="anchor-link" to="education" spy={true} smooth={true} duration={500} >Education</Link>
+                                <Link onClick={() => dataNavClicked("ethnicity")} activeClass="active" className="anchor-link" to="ethnicity" spy={true} smooth={true} duration={500} >Ethnicity</Link>
+                                <Link onClick={() => dataNavClicked("population")} activeClass="active" className="anchor-link" to="population" spy={true} smooth={true} duration={500} >Population</Link>
                             </div>
                             : null}
                         </div>

--- a/src/components/map-components/Map.scss
+++ b/src/components/map-components/Map.scss
@@ -315,7 +315,7 @@
     .nav-bottom-anchor {
         width:20%;
         position:absolute;
-        bottom: -3200px;
+        bottom: -3250px;
         
         
     }

--- a/src/components/map-components/Map.scss
+++ b/src/components/map-components/Map.scss
@@ -313,14 +313,9 @@
     }
 
     .nav-bottom-anchor {
-        
         height:100%;
         justify-content:flex-end;
-        padding-bottom:130px;
-        // position:absolute;
-        // bottom: -3250px;
-        
-        
+        padding-bottom:130px;       
     }
 
     .data-by-category {

--- a/src/components/map-components/Map.scss
+++ b/src/components/map-components/Map.scss
@@ -313,9 +313,12 @@
     }
 
     .nav-bottom-anchor {
-        width:20%;
-        position:absolute;
-        bottom: -3250px;
+        
+        height:100%;
+        justify-content:flex-end;
+        padding-bottom:130px;
+        // position:absolute;
+        // bottom: -3250px;
         
         
     }

--- a/src/components/map-components/Map.scss
+++ b/src/components/map-components/Map.scss
@@ -8,6 +8,8 @@
     max-width:1000px;
 }
 
+
+
 /* this refers to the whole page (does not include navigation */
 
 .map-page {
@@ -105,6 +107,8 @@
                 }
             }
         }
+
+
 
         .slider {
             width: 100%;
@@ -217,9 +221,14 @@
             display:flex;
             justify-content:space-between;
             width:100%;
+            align-content:center;;
         }
 
-        span {
+        .color-legend-text {
+            color:black;
+        }
+
+        .delete-icon {
             cursor:pointer;
         }
 

--- a/src/components/map-components/Map.scss
+++ b/src/components/map-components/Map.scss
@@ -312,6 +312,14 @@
         width: 20%;
     }
 
+    .nav-bottom-anchor {
+        width:20%;
+        position:absolute;
+        bottom: -3200px;
+        
+        
+    }
+
     .data-by-category {
         width: 73%;
         margin-left:4%;

--- a/src/components/map-components/MapSearch.js
+++ b/src/components/map-components/MapSearch.js
@@ -15,8 +15,10 @@ const MapSearch = ({menu, search, onSearch, setSearch, cityMarkers, viewport, se
     
     
     const chooseSuggestion = city => {
+        
         ReactGA.event({ category: 'Search', 
         action: `used autofill` });
+
         setSearch(city.name.replace(" city", ""));
         selectSearch(city);
         setSuggestions([]);

--- a/src/components/map-components/MapSearch.js
+++ b/src/components/map-components/MapSearch.js
@@ -1,4 +1,5 @@
 import React, {useState} from "react";
+import ReactGA from "react-ga";
 
 
 const MapSearch = ({menu, search, onSearch, setSearch, cityMarkers, viewport, setViewport,selectSearch}) => {
@@ -15,7 +16,7 @@ const MapSearch = ({menu, search, onSearch, setSearch, cityMarkers, viewport, se
     
     
     const chooseSuggestion = city => {
-        
+
         ReactGA.event({ category: 'Search', 
         action: `used autofill` });
 

--- a/src/components/map-components/MapSearch.js
+++ b/src/components/map-components/MapSearch.js
@@ -15,6 +15,8 @@ const MapSearch = ({menu, search, onSearch, setSearch, cityMarkers, viewport, se
     
     
     const chooseSuggestion = city => {
+        ReactGA.event({ category: 'Search', 
+        action: `used autofill` });
         setSearch(city.name.replace(" city", ""));
         selectSearch(city);
         setSuggestions([]);


### PR DESCRIPTION
- Anchors fixed nav so it doesn't scroll over the footer
- Filters city markers based on map zoom and population
- Adds several google analytics events related to data browsing

I have yet to figure out an elegant way to change the styling of the navigation when in the map component - I'd like to unfix the navigation for two reasons
1. I think it's unnecessary to have it follow you and occlude your vision of the core app functionality
2. It affects my sticky navbar and scrolling breakpoints - there is likely a library-based solution to this but I think having the nav not be fixed on the map is the superior solution