### PR TITLE
Adds amplify.yml for Amplify pre-build and build commands.

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,16 @@
+version: 0.1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - yarn install
+    build:
+      commands:
+        - yarn run build
+  artifacts:
+    baseDirectory: build
+    files:
+      - '**/*'
+  cache:
+    paths:
+      - node_modules/**/*


### PR DESCRIPTION
We've added an amplify.yml file due to an ongoing issue with Amplify's caching of the node_modules folder. When dependencies update, the node_modules cached on Amplify become out of date and build will fail.

If build fails due to said issue, add the following line to prebuild commands in amplify.yml, just before "- yarn install":

- rm -rf node_modules

Once you've added this line, it will fully reinstall dependencies rather than relying on the cached version. You can remove the line again once the build succeeds.