### PR TITLE
fixes data science url to https

### DIFF
--- a/src/utils/axiosDataScience.js
+++ b/src/utils/axiosDataScience.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 export const cityDataBaseUrl =
-  "http://api.citrics.io/jkekal6d6e5si3i2ld66d4dl/citydata/";
+  "https://api.citrics.io/jkekal6d6e5si3i2ld66d4dl/citydata/";
 //Axios call to get data about a city from the api using id
 export function cityDataById() {
   return axios.create({


### PR DESCRIPTION
Was getting this error on production: Mixed Content: The page at '<URL>' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint '<URL>'. This request has been blocked; the content must be served over HTTPS.

Changed the url to https.