### PR TITLE
Bug/industry trends

### DIFF
--- a/src/components/pages/comparison/DataDisplay.js
+++ b/src/components/pages/comparison/DataDisplay.js
@@ -102,9 +102,22 @@ const DataDisplay = ({
                 </p>
               </Card>
 
-              <Card title={"Job Industry Trends"}>
-                <IndustryLineGraph selected={selected} />
-              </Card>
+              {/* Array.every() returns true if every item meets the condition.
+              This way if none of the cities have Industry Trend data the component won't even be rendered.  
+              */}
+              {selected.every((item, index, array) => {
+                return !item["Industry_Trends"];
+              }) ? (
+                <Card title={"Job Industry Trends"}>
+                  <IndustryLineGraph
+                    selected={selected.filter(
+                      (item) => item["Industry_Trends"]
+                    )}
+                  />
+                </Card>
+              ) : (
+                <></>
+              )}
 
               <Card title={"Ways to Commute"} gridColumn={9}>
                 <Commute edData={selected} />

--- a/src/components/pages/comparison/DataDisplay.js
+++ b/src/components/pages/comparison/DataDisplay.js
@@ -108,6 +108,8 @@ const DataDisplay = ({
               {selected.every((item, index, array) => {
                 return !item["Industry_Trends"];
               }) ? (
+                <></>
+              ) : (
                 <Card title={"Job Industry Trends"}>
                   <IndustryLineGraph
                     selected={selected.filter(
@@ -115,8 +117,6 @@ const DataDisplay = ({
                     )}
                   />
                 </Card>
-              ) : (
-                <></>
               )}
 
               <Card title={"Ways to Commute"} gridColumn={9}>

--- a/src/components/pages/comparison/DataDisplay.js
+++ b/src/components/pages/comparison/DataDisplay.js
@@ -111,11 +111,7 @@ const DataDisplay = ({
                 <></>
               ) : (
                 <Card title={"Job Industry Trends"}>
-                  <IndustryLineGraph
-                    selected={selected.filter(
-                      (item) => item["Industry_Trends"]
-                    )}
-                  />
+                  <IndustryLineGraph selected={selected} />
                 </Card>
               )}
 

--- a/src/components/pages/comparison/graphs/economics/IndustryLineGraph.js
+++ b/src/components/pages/comparison/graphs/economics/IndustryLineGraph.js
@@ -3,6 +3,7 @@ import { Line } from "react-chartjs-2";
 import styled from "styled-components";
 import Select from "@material-ui/core/Select";
 import MenuItem from "@material-ui/core/MenuItem";
+import useMediaQuery from "@material-ui/core/useMediaQuery";
 
 import { actionColor } from "../../../../../utils/cityColors.js";
 import * as ChartAnnotation from "chartjs-plugin-annotation";
@@ -31,6 +32,8 @@ const SelectPrompt = styled.p`
 `;
 
 export default function IndustryLineGraph({ selected }) {
+  const mobile = useMediaQuery("(max-width:600px)");
+
   // The selected cities, filtered for any cities that don't have industry trend data.
   const [citiesWithData, setCitiesWithData] = useState([]);
   useEffect(() => {
@@ -144,6 +147,7 @@ export default function IndustryLineGraph({ selected }) {
         <Line
           data={{ labels: dateKeys, datasets: lines }}
           options={{
+            responsive: true,
             plugins: [ChartAnnotation],
             annotation: {
               annotations: [
@@ -181,7 +185,7 @@ export default function IndustryLineGraph({ selected }) {
                     labelString: "Year",
                   },
                   ticks: {
-                    maxTicksLimit: 24,
+                    maxTicksLimit: mobile ? 12 : 24,
                   },
                 },
               ],

--- a/src/components/pages/comparison/graphs/economics/IndustryLineGraph.js
+++ b/src/components/pages/comparison/graphs/economics/IndustryLineGraph.js
@@ -169,6 +169,7 @@ export default function IndustryLineGraph({ selected }) {
             },
             legend: {
               display: true,
+              position: "bottom",
             },
             scales: {
               xAxes: [

--- a/src/components/pages/comparison/graphs/economics/IndustryLineGraph.js
+++ b/src/components/pages/comparison/graphs/economics/IndustryLineGraph.js
@@ -189,14 +189,14 @@ export default function IndustryLineGraph({ selected }) {
                 {
                   display: true,
                   ticks: {
-                    userCallback: (value, index, values) => {
-                      return `$${numberCommas(value)}`;
+                    userCallback: (value) => {
+                      return `${value * 1000}`;
                     },
                   },
                   gridLines: { display: true },
                   scaleLabel: {
                     display: true,
-                    labelString: "Amount",
+                    labelString: "Jobs Available",
                     ticks: { beginAtZero: false },
                   },
                 },

--- a/src/components/pages/comparison/graphs/economics/IndustryLineGraph.js
+++ b/src/components/pages/comparison/graphs/economics/IndustryLineGraph.js
@@ -36,6 +36,9 @@ export default function IndustryLineGraph({ selected }) {
   useEffect(() => {
     setCitiesWithData(selected.filter((city) => city["Industry_Trends"]));
   }, [selected]);
+  useEffect(() => {
+    console.log(citiesWithData.length);
+  }, [citiesWithData]);
 
   // The currently selected industry.
   const [currentIndustry, setCurrentIndustry] = useState(
@@ -157,7 +160,7 @@ export default function IndustryLineGraph({ selected }) {
               fontSize: 25,
             },
             legend: {
-              display: false,
+              display: true,
             },
             scales: {
               xAxes: [
@@ -203,18 +206,16 @@ export default function IndustryLineGraph({ selected }) {
           </Select>
         </SelectContainer>
         {/* If even one of the cities doesn't have data we will display a message. */}
-        {selected.some((item) => !item["Industry_Trends"]) ? (
-          <>
-            {" "}
-            <p>
-              No data available for:{" "}
-              {selected
-                .filter((city) => !city["Industry_Trends"])
-                .map((city) => (
-                  <>{city["name_with_com"]}</>
-                ))}
-            </p>
-          </>
+        {selected.some((city) => !city["Industry_Trends"]) ? (
+          <p style={{ textAlign: "center" }}>
+            No industry trend data available for:{" "}
+            {selected
+              .filter((city) => !city["Industry_Trends"])
+              .map((city) => (
+                <>{city["name_with_com"]}</>
+              ))}
+            .
+          </p>
         ) : (
           <></>
         )}

--- a/src/components/pages/comparison/graphs/economics/IndustryLineGraph.js
+++ b/src/components/pages/comparison/graphs/economics/IndustryLineGraph.js
@@ -180,6 +180,9 @@ export default function IndustryLineGraph({ selected }) {
                     display: true,
                     labelString: "Year",
                   },
+                  ticks: {
+                    maxTicksLimit: 24,
+                  },
                 },
               ],
               yAxes: [

--- a/src/components/pages/comparison/graphs/economics/IndustryLineGraph.js
+++ b/src/components/pages/comparison/graphs/economics/IndustryLineGraph.js
@@ -36,9 +36,6 @@ export default function IndustryLineGraph({ selected }) {
   useEffect(() => {
     setCitiesWithData(selected.filter((city) => city["Industry_Trends"]));
   }, [selected]);
-  useEffect(() => {
-    console.log(citiesWithData.length);
-  }, [citiesWithData]);
 
   // The X axis labels, dates available. (These are standardized on the backend, they will always be the same.)
   const [dateKeys, setDateKeys] = useState([]);
@@ -101,7 +98,6 @@ export default function IndustryLineGraph({ selected }) {
           )
         )
       );
-      console.log(keys);
       setIndustryKeys(keys);
     }
   }, [citiesWithData]);

--- a/src/components/pages/comparison/graphs/economics/IndustryLineGraph.js
+++ b/src/components/pages/comparison/graphs/economics/IndustryLineGraph.js
@@ -168,7 +168,7 @@ export default function IndustryLineGraph({ selected }) {
             },
             title: {
               display: false,
-              text: "house price",
+              text: "Industry Trends",
               fontSize: 25,
             },
             legend: {
@@ -190,13 +190,13 @@ export default function IndustryLineGraph({ selected }) {
                   display: true,
                   ticks: {
                     userCallback: (value) => {
-                      return `${value * 1000}`;
+                      return `${numberCommas(value * 1000)}`;
                     },
                   },
                   gridLines: { display: true },
                   scaleLabel: {
                     display: true,
-                    labelString: "Jobs Available",
+                    labelString: "Jobs",
                     ticks: { beginAtZero: false },
                   },
                 },

--- a/src/components/pages/comparison/graphs/housing/House_price.js
+++ b/src/components/pages/comparison/graphs/housing/House_price.js
@@ -157,6 +157,9 @@ export default function HousePriceGraph({ selected }) {
                     display: true,
                     labelString: "Year",
                   },
+                  ticks: {
+                    maxTicksLimit: 24,
+                  },
                 },
               ],
               yAxes: [

--- a/src/components/pages/comparison/graphs/housing/House_price.js
+++ b/src/components/pages/comparison/graphs/housing/House_price.js
@@ -108,20 +108,6 @@ export default function HousePriceGraph({ selected }) {
     setLines(formatGraphLinesWithMultipleCities(selected, dateKeys));
   }, [selected, dateKeys]);
 
-  const handleClickLegend = (e, legendItem) => {
-    if (lines.length > 1) {
-      setLines(
-        formatGraphLinesWithOneCity(selected[legendItem.datasetIndex], dateKeys)
-      );
-    } else {
-      setLines(formatGraphLinesWithMultipleCities(selected, dateKeys));
-    }
-  };
-
-  const handleClickShowAll = () => {
-    setLines(formatGraphLinesWithMultipleCities(selected, dateKeys));
-  };
-
   // This numberCommas Function generates commas for the y axis in this case dollar amounts that exceed 3 zeros.
   function numberCommas(x) {
     return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
@@ -161,7 +147,6 @@ export default function HousePriceGraph({ selected }) {
             legend: {
               display: true,
               position: "bottom",
-              onClick: handleClickLegend,
             },
             scales: {
               xAxes: [
@@ -194,18 +179,6 @@ export default function HousePriceGraph({ selected }) {
           }}
         />
       </div>
-      {selected.length > 1 && lines.length === 1 ? (
-        <Button onClick={handleClickShowAll}>Show All</Button>
-      ) : (
-        <></>
-      )}
-      {selected.length !== 1 && lines.length > 1 ? (
-        <p style={{ margin: "0 auto", textAlign: "center" }}>
-          Click a city on the legend to enter a more detailed view.
-        </p>
-      ) : (
-        <></>
-      )}
     </div>
   );
 }

--- a/src/components/pages/comparison/graphs/housing/House_price.js
+++ b/src/components/pages/comparison/graphs/housing/House_price.js
@@ -1,6 +1,9 @@
 import React, { useState, useEffect } from "react";
 import { Line } from "react-chartjs-2";
 import styled from "styled-components";
+
+import useMediaQuery from "@material-ui/core/useMediaQuery";
+
 import { actionColor } from "../../../../../utils/cityColors.js";
 import * as ChartAnnotation from "chartjs-plugin-annotation";
 
@@ -20,6 +23,8 @@ const Button = styled.button`
 `;
 
 export default function HousePriceGraph({ selected }) {
+  const mobile = useMediaQuery("(max-width:600px)");
+
   // Get the current date for the purpose of
   // determining where to place the vertical line divider
   const currentDate = new Date();
@@ -158,7 +163,7 @@ export default function HousePriceGraph({ selected }) {
                     labelString: "Year",
                   },
                   ticks: {
-                    maxTicksLimit: 24,
+                    maxTicksLimit: mobile ? 12 : 24,
                   },
                 },
               ],


### PR DESCRIPTION
# Description

This PR fixes issues with the Industry Trends graph, where cities without data for specific industries (or without data for any industries at all) might cause the app to crash. 

- If none of the cities have industry data the graph isn't shown at all.
- If one of the cities doesn't have industry data it isn't shown on the graph, and a message at the bottom of the graph indicates that it has no data.
- If one of the cities doesn't have industry data for a specific industry, it isn't shown on the graph, and a message at the bottom of the graph indicates that it has no data.

It also fixes the Y axis labels, which displayed values in USD instead of indicating the number of jobs available.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Complete, tested, ready to review and merge

# Checklist:
Everything in this checklist is required for each PR.  Please do not approve a PR that does not have all of these items.  

- [x] I have pulled from master before submitting this PR
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer (the peer review to approve a PR counts.  The reviewer must download and test the code)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts